### PR TITLE
Fix: Update provider support validation

### DIFF
--- a/src/celeste_image_edit/providers/google.py
+++ b/src/celeste_image_edit/providers/google.py
@@ -6,6 +6,7 @@ from celeste_core import ImageArtifact
 from celeste_core.base.image_editor import BaseImageEditor
 from celeste_core.config.settings import settings
 from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
 from celeste_core.models.registry import supports
 from google import genai
 from google.genai import types
@@ -17,7 +18,9 @@ class GoogleImageEditor(BaseImageEditor):
     ) -> None:
         self.client = genai.Client(api_key=settings.google.api_key)
         self.model_name = model
-        self.is_supported = supports(self.model_name, Capability.IMAGE_EDIT)
+        self.is_supported = supports(
+            Provider.GOOGLE, self.model_name, Capability.IMAGE_EDIT
+        )
 
     async def edit_image(
         self, prompt: str, image: ImageArtifact, **kwargs: Any

--- a/src/celeste_image_edit/providers/replicate.py
+++ b/src/celeste_image_edit/providers/replicate.py
@@ -8,6 +8,7 @@ from celeste_core import ImageArtifact
 from celeste_core.base.image_editor import BaseImageEditor
 from celeste_core.config.settings import settings
 from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
 from celeste_core.models.registry import supports
 
 
@@ -19,7 +20,9 @@ class ReplicateImageEditor(BaseImageEditor):
         self.model_name = model
         # Guard against non-edit models (e.g., qwen/qwen-image is generation-only)
         # Non-raising validation; store support state for callers to inspect
-        self.is_supported = supports(self.model_name, Capability.IMAGE_EDIT)
+        self.is_supported = supports(
+            Provider.REPLICATE, self.model_name, Capability.IMAGE_EDIT
+        )
 
     async def edit_image(
         self, prompt: str, image: ImageArtifact, **kwargs: Any


### PR DESCRIPTION
## Summary
- Updated `supports()` function calls to include the `Provider` enum parameter for proper provider-specific capability validation
- Fixed OpenAI image buffer handling by adding name attribute for MIME type detection  
- Ensured consistent validation across Google, OpenAI, and Replicate providers

## Changes
- Added `Provider` enum import to all provider modules
- Updated `supports()` calls to include provider parameter (e.g., `Provider.GOOGLE`, `Provider.OPENAI`, `Provider.REPLICATE`)
- Fixed OpenAI image buffer to include `name` attribute for proper MIME type detection

## Test Plan
- [ ] Verify image editing works with Google provider
- [ ] Verify image editing works with OpenAI provider  
- [ ] Verify image editing works with Replicate provider
- [ ] Confirm capability validation correctly identifies supported models for each provider