### PR TITLE
refactor: Extract provider mapping to separate module

### DIFF
--- a/src/celeste_image_edit/__init__.py
+++ b/src/celeste_image_edit/__init__.py
@@ -4,10 +4,11 @@ Celeste Image Generation: A unified image generation interface for multiple prov
 
 from typing import Any
 
-from celeste_core import Provider, list_models
+from celeste_core import Provider
 from celeste_core.base.image_editor import BaseImageEditor
 from celeste_core.config.settings import settings
-from celeste_core.enums.capability import Capability
+
+from .mapping import PROVIDER_MAPPING
 
 __version__ = "0.1.0"
 
@@ -27,23 +28,13 @@ def create_image_editor(provider: str | Provider, **kwargs: Any) -> BaseImageEdi
         provider if isinstance(provider, Provider) else Provider(provider)
     )
 
-    # Ensure there is at least one registered model for this provider/capability
-    if not list_models(provider=provider_enum, capability=Capability.IMAGE_EDIT):
-        msg = f"No models for provider {provider_enum} with capability IMAGE_EDIT"
-        raise ValueError(msg)
+    if provider_enum not in PROVIDER_MAPPING:
+        raise ValueError(f"No editor mapping for provider: {provider_enum}")
 
     # Validate environment for the chosen provider
     settings.validate_for_provider(provider_enum.value)
 
-    mapping = {
-        Provider.GOOGLE: (".providers.google", "GoogleImageEditor"),
-        Provider.REPLICATE: (".providers.replicate", "ReplicateImageEditor"),
-        Provider.OPENAI: (".providers.openai", "OpenAIImageEditor"),
-    }
-
-    if provider_enum not in mapping:
-        raise ValueError(f"No editor mapping for provider: {provider_enum}")
-    module_path, class_name = mapping[provider_enum]
+    module_path, class_name = PROVIDER_MAPPING[provider_enum]
     module = __import__(f"celeste_image_edit{module_path}", fromlist=[class_name])
     editor_class = getattr(module, class_name)
     return editor_class(**kwargs)

--- a/src/celeste_image_edit/mapping.py
+++ b/src/celeste_image_edit/mapping.py
@@ -1,0 +1,14 @@
+from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
+
+# Capability for this domain package
+CAPABILITY: Capability = Capability.IMAGE_EDIT
+
+# Provider wiring for image editing clients
+PROVIDER_MAPPING: dict[Provider, tuple[str, str]] = {
+    Provider.GOOGLE: (".providers.google", "GoogleImageEditor"),
+    Provider.REPLICATE: (".providers.replicate", "ReplicateImageEditor"),
+    Provider.OPENAI: (".providers.openai", "OpenAIImageEditor"),
+}
+
+__all__ = ["CAPABILITY", "PROVIDER_MAPPING"]


### PR DESCRIPTION
## Summary
• Extracted provider-to-class mapping from `__init__.py` to dedicated `mapping.py` module
• Removed model validation logic from `create_image_editor` function 
• Improved code organization and maintainability

## Test plan
- [ ] Verify existing tests pass
- [ ] Test image editor creation for all supported providers (Google, Replicate, OpenAI)
- [ ] Confirm proper error handling for unsupported providers

🤖 Generated with [Claude Code](https://claude.ai/code)