### PR TITLE
refactor: Standardize model attribute name across providers

### DIFF
--- a/src/celeste_image_edit/providers/google.py
+++ b/src/celeste_image_edit/providers/google.py
@@ -17,10 +17,8 @@ class GoogleImageEditor(BaseImageEditor):
         self, model: str = "gemini-2.0-flash-preview-image-generation", **kwargs: Any
     ) -> None:
         self.client = genai.Client(api_key=settings.google.api_key)
-        self.model_name = model
-        self.is_supported = supports(
-            Provider.GOOGLE, self.model_name, Capability.IMAGE_EDIT
-        )
+        self.model = model
+        self.is_supported = supports(Provider.GOOGLE, self.model, Capability.IMAGE_EDIT)
 
     async def edit_image(
         self, prompt: str, image: ImageArtifact, **kwargs: Any
@@ -31,7 +29,7 @@ class GoogleImageEditor(BaseImageEditor):
             img = PIL.Image.open(io.BytesIO(image.data))
 
         response = await self.client.aio.models.generate_content(
-            model=self.model_name,
+            model=self.model,
             contents=[prompt, img],
             config=types.GenerateContentConfig(response_modalities=["IMAGE", "TEXT"]),
         )
@@ -49,4 +47,4 @@ class GoogleImageEditor(BaseImageEditor):
                 )
 
         # Non-raising: return empty artifact if provider returned no image
-        return ImageArtifact(data=None, metadata={"model": self.model_name})
+        return ImageArtifact(data=None, metadata={"model": self.model})

--- a/src/celeste_image_edit/providers/openai.py
+++ b/src/celeste_image_edit/providers/openai.py
@@ -18,11 +18,9 @@ class OpenAIImageEditor(BaseImageEditor):
     def __init__(self, model: str = "gpt-image-1", **kwargs: Any) -> None:
         # Base initializer intentionally not called because it's abstract
         self.client = OpenAI(api_key=settings.openai.api_key)
-        self.model_name = model
+        self.model = model
         # Non-raising validation; store support state for callers to inspect
-        self.is_supported = supports(
-            Provider.OPENAI, self.model_name, Capability.IMAGE_EDIT
-        )
+        self.is_supported = supports(Provider.OPENAI, self.model, Capability.IMAGE_EDIT)
 
     async def edit_image(
         self, prompt: str, image: ImageArtifact, **kwargs: Any
@@ -32,7 +30,7 @@ class OpenAIImageEditor(BaseImageEditor):
             if image.path:
                 with open(image.path, "rb") as img_file:
                     resp = self.client.images.edit(
-                        model=self.model_name,
+                        model=self.model,
                         image=img_file,
                         prompt=prompt,
                         size=kwargs.get("size", "1024x1024"),
@@ -49,7 +47,7 @@ class OpenAIImageEditor(BaseImageEditor):
                 image_buffer = io.BytesIO(image.data)
                 image_buffer.name = "image.png"  # Add name for MIME type
                 resp = self.client.images.edit(
-                    model=self.model_name,
+                    model=self.model,
                     image=image_buffer,
                     prompt=prompt,
                     size=kwargs.get("size", "1024x1024"),
@@ -64,6 +62,6 @@ class OpenAIImageEditor(BaseImageEditor):
         return ImageArtifact(
             data=image_bytes,
             metadata={
-                "model": self.model_name,
+                "model": self.model,
             },
         )

--- a/src/celeste_image_edit/providers/replicate.py
+++ b/src/celeste_image_edit/providers/replicate.py
@@ -17,11 +17,11 @@ class ReplicateImageEditor(BaseImageEditor):
         self, model: str = "black-forest-labs/flux-kontext-pro", **kwargs: Any
     ) -> None:
         self.client = replicate.Client(api_token=settings.replicate.api_token)
-        self.model_name = model
+        self.model = model
         # Guard against non-edit models (e.g., qwen/qwen-image is generation-only)
         # Non-raising validation; store support state for callers to inspect
         self.is_supported = supports(
-            Provider.REPLICATE, self.model_name, Capability.IMAGE_EDIT
+            Provider.REPLICATE, self.model, Capability.IMAGE_EDIT
         )
 
     async def edit_image(
@@ -30,7 +30,7 @@ class ReplicateImageEditor(BaseImageEditor):
         # Choose the most likely input key; allow override,
         # but we will fallback across common keys
         preferred_key: str | None = kwargs.pop("input_key", None)
-        default_key = "input_image" if "kontext" in self.model_name else "image"
+        default_key = "input_image" if "kontext" in self.model else "image"
         candidate_keys = [
             k
             for k in [
@@ -97,7 +97,7 @@ class ReplicateImageEditor(BaseImageEditor):
             image_value = _prepare_image_value(image)
 
             output = self.client.run(
-                self.model_name,
+                self.model,
                 input={
                     "prompt": prompt,
                     key: image_value,
@@ -115,7 +115,7 @@ class ReplicateImageEditor(BaseImageEditor):
         return ImageArtifact(
             data=image_bytes,
             metadata={
-                "model": self.model_name,
+                "model": self.model,
                 **({"output_url": output_url} if output_url else {}),
             },
         )


### PR DESCRIPTION
## Summary
• Replace `model_name` attribute with `model` in Google, OpenAI, and Replicate image editor providers
• Improves consistency across the codebase by using a standardized attribute name
• No functional changes, purely refactoring for consistency

## Test plan
- [ ] Existing tests should continue to pass
- [ ] Verify all provider classes use the standardized `model` attribute
- [ ] Check that model validation and metadata still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)