### PR TITLE
refactor: Organize imports in Replicate provider

### DIFF
--- a/src/celeste_image_edit/providers/replicate.py
+++ b/src/celeste_image_edit/providers/replicate.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import io
-from typing import Any
+import urllib.request
+from typing import Any, cast
 
 import replicate
 from celeste_core import ImageArtifact
@@ -51,9 +52,6 @@ class ReplicateImageEditor(BaseImageEditor):
 
     def _download(self, url: str) -> bytes:
         """Download image from URL."""
-        import urllib.request
-        from typing import cast
-
         with urllib.request.urlopen(url) as resp:
             return cast(bytes, resp.read())
 


### PR DESCRIPTION
## Summary
- Move `urllib.request` and `cast` imports to module level for better code organization
- Follow Python import conventions with all imports at the top of the file
- Improve code consistency across the codebase

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] No functional changes - only import reorganization
- [ ] Verify Replicate provider still works correctly with image editing

🤖 Generated with [Claude Code](https://claude.ai/code)